### PR TITLE
Card typings resolution

### DIFF
--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.5",
   "license": "MIT",
   "main": "lib/index",
+  "typings": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-mdc/react-material-components-web.git"


### PR DESCRIPTION
Fixes import issue with [@reactmdc/card](https://github.com/react-mdc/react-material-components-web/tree/develop/packages/card) which now resolve to `index.d.ts`