### PR TITLE
Add className to Button's MetaProps

### DIFF
--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -26,6 +26,7 @@ export type MetaProps = {
     compact?: boolean,
     primary?: boolean,
     accent?: boolean,
+    className?: string,
 };
 
 export type ChildProps = {


### PR DESCRIPTION
Fix error TS2559: Type 'MetaProps' has no properties in common with type 'ClassNameProps'.